### PR TITLE
Fix zlib 1.2.11 download link invalid, update to 1.2.13

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -121,9 +121,9 @@ deps = {
         "bins": ["cjpeg.exe", "djpeg.exe"],
     },
     "zlib": {
-        "url": "http://zlib.net/zlib1211.zip",
-        "filename": "zlib1211.zip",
-        "dir": "zlib-1.2.11",
+        "url": "http://zlib.net/zlib1213.zip",
+        "filename": "zlib1213.zip",
+        "dir": "zlib-1.2.13",
         "build": [
             cmd_nmake(r"win32\Makefile.msc", "clean"),
             cmd_nmake(r"win32\Makefile.msc", "zlib.lib"),


### PR DESCRIPTION
build successfully 
test env: win 10 x64; cl 19.35.32215; python 3.11.2;
build cmd: 
    cd path\pillow-avif-plugin-1.3.1\winbuild
    python3 build_prepare.py
    cd path\pillow-avif-plugin-1.3.1\winbuild\build
    build_dep_all.cmd
    # install_pillow.cmd
    # install_meson.cmd
    build_pillow_avif_plugin.cmd
    python setup.py install

use:  
    import PIL.Image
    import pillow_avif
    img = PIL.Image.open("path/img_name.avif")