### PR TITLE
Expose depth parameter to the public API.

### DIFF
--- a/src/pillow_avif/AvifImagePlugin.py
+++ b/src/pillow_avif/AvifImagePlugin.py
@@ -144,6 +144,7 @@ def _save(im, fp, filename, save_all=False):
     duration = info.get("duration", 0)
     subsampling = info.get("subsampling", "4:2:0")
     speed = info.get("speed", 6)
+    depth = info.get("bit_depth", 8)
     codec = info.get("codec", "auto")
     range_ = info.get("range", "full")
     tile_rows_log2 = info.get("tile_rows", 0)
@@ -187,6 +188,7 @@ def _save(im, fp, filename, save_all=False):
         qmin,
         qmax,
         speed,
+        depth,
         codec,
         range_,
         tile_rows_log2,

--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -206,6 +206,7 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
     int qmin = AVIF_QUANTIZER_BEST_QUALITY;  // =0
     int qmax = 10;                           // "High Quality", but not lossless
     int speed = 8;
+    int depth = 8;
     PyObject *icc_bytes;
     PyObject *exif_bytes;
     PyObject *xmp_bytes;
@@ -221,13 +222,14 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "IIsiiissiiOOSSSO",
+            "IIsiiiissiiOOSSSO",
             &width,
             &height,
             &subsampling,
             &qmin,
             &qmax,
             &speed,
+            &depth,
             &codec,
             &range,
             &tile_rows_log2,
@@ -348,7 +350,7 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
         image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
         image->width = width;
         image->height = height;
-        image->depth = 8;
+        image->depth = depth;
 #if AVIF_VERSION >= 90000
         image->alphaPremultiplied = enc_options.alpha_premultiplied;
 #endif
@@ -475,6 +477,7 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
 
     avifRGBImageSetDefaults(&rgb, frame);
     rgb.depth = 8;
+//    rgb.depth = frame->depth != 0 ? rgb.depth : 8;
 
     if (strcmp(mode, "RGBA") == 0) {
         rgb.format = AVIF_RGB_FORMAT_RGBA;
@@ -753,6 +756,7 @@ _decoder_get_frame(AvifDecoderObject *self, PyObject *args) {
     avifRGBImageSetDefaults(&rgb, image);
 
     rgb.depth = 8;
+//    rgb.depth = image->depth != 0 ? image->depth : 8;
 
     if (decoder->alphaPresent) {
         rgb.format = AVIF_RGB_FORMAT_RGBA;


### PR DESCRIPTION
Hello!

I found that this Pillow plugin what I need for working with AVIF images. In my work I need to work with 10-bit and 12-bit images.
I tried to expose the color depth as parameter to the public API.
The encoding seems to work but I am not sure everything is alright. There are 2 commented lines where I had an attempt to update the **_depth_** parameter. Using the commented code yields into exceptions, my guess is that those are from YUV<->RGB conversions.

Another parameter which I found useful for the public API would be to manage the thread count used by encoder. This is an idea for future work.

Since this is my first public contribution to a project, I am looking forward for you opinion on this and to work with you on adding this new functionality.