### PR TITLE
Configure max_threads max value to 64

### DIFF
--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -448,8 +448,6 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
             init_max_threads();
         }
 
-        max_threads = 96;
-
         if (strcmp(codec, "aom") == 0 || strcmp(codec, "avm") == 0){
             if (max_threads > 64 ) {
                 // Encoding with libaom and libavm will fail if

--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -86,6 +86,11 @@ init_max_threads(void) {
     }
 
     max_threads = (int)num_cpus;
+    // The max allowable value of maxThreads for AVIF
+    // encoders is 64. The encoder crashes otherwise.
+    if (max_threads > 64) {
+        max_threads = 64;
+    }
 
 done:
     Py_XDECREF(os);

--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -448,15 +448,11 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
             init_max_threads();
         }
 
-        if (strcmp(codec, "aom") == 0 || strcmp(codec, "avm") == 0){
-            if (max_threads > 64 ) {
-                // Encoding with libaom and libavm will fail if
-                // encoder->maxThreads is set higher than 64
-                max_threads = 64;
-            }
-        }
+        int is_aom_encode = strcmp(codec, "aom") == 0 ||
+                            (strcmp(codec, "auto") == 0 &&
+                             _codec_available("aom", AVIF_CODEC_FLAG_CAN_ENCODE));
 
-        encoder->maxThreads = max_threads;
+        encoder->maxThreads = is_aom_encode && max_threads > 64 ? 64 : max_threads;
 #if AVIF_VERSION >= 1000000
         if (enc_options.qmin != -1 && enc_options.qmax != -1) {
             encoder->minQuantizer = enc_options.qmin;

--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -86,11 +86,6 @@ init_max_threads(void) {
     }
 
     max_threads = (int)num_cpus;
-    // The max allowable value of maxThreads for AVIF
-    // encoders is 64. The encoder crashes otherwise.
-    if (max_threads > 64) {
-        max_threads = 64;
-    }
 
 done:
     Py_XDECREF(os);
@@ -451,6 +446,16 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
 
         if (max_threads == 0) {
             init_max_threads();
+        }
+
+        max_threads = 96;
+
+        if (strcmp(codec, "aom") == 0 || strcmp(codec, "avm") == 0){
+            if (max_threads > 64 ) {
+                // Encoding with libaom and libavm will fail if
+                // encoder->maxThreads is set higher than 64
+                max_threads = 64;
+            }
         }
 
         encoder->maxThreads = max_threads;


### PR DESCRIPTION
Add upper bound of 64 to max_threads in init_max_threads() so that encoding does not crash on machines with high core counts.

See the repro and discussion in issue #23 

Before this change (on a machine with 96 cores):
Script:
```
from PIL import Image
import pillow_avif
import numpy as np
from pathlib import Path

def main():
    arr = np.ones((128, 128, 3), dtype=np.uint8)
    img_orig = Image.fromarray(arr)
    out_path = Path("/tmp") / f"foobar.avif"
    print(f"Saving to {out_path}")
    img_orig.save(out_path)

if __name__ == "__main__":
    main()
```

Output:
```
RuntimeError: Failed to encode image: Encoding of color planes failed
```

After this change: program works as expected.
