### PR TITLE
chore(gha): Update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: reviewdog/action-setup@v1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       LIBAVIF_VERSION: ${{ matrix.libavif-version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       if: matrix.python-version != '2.7'
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up shell
         run: echo "C:\msys64\usr\bin\" >> $env:GITHUB_PATH

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -93,18 +93,18 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.arch == 'arm' && '11.0' || '10.10' }}
       MB_ML_LIBC: ${{ matrix.mb-ml-libc }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: pillow-avif-plugin
 
       - name: Checkout dependencies
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: fdintino/pillow-avif-plugin-depends
           path: pillow-avif-plugin-depends
 
       - name: Checkout multibuild
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: multi-build/multibuild
           path: multibuild
@@ -176,10 +176,10 @@ jobs:
 
     steps:
     - name: Checkout pillow-avif-plugin
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Checkout cached dependencies
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: python-pillow/pillow-depends
         path: winbuild\depends


### PR DESCRIPTION
Resolve deprecation warnings, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/