### PR TITLE
Let users pass max_threads as an argument to _avif.AvifDecoder

### DIFF
--- a/src/pillow_avif/AvifImagePlugin.py
+++ b/src/pillow_avif/AvifImagePlugin.py
@@ -138,6 +138,7 @@ def _save(im, fp, filename, save_all=False):
     duration = info.get("duration", 0)
     subsampling = info.get("subsampling", "4:2:0")
     speed = info.get("speed", 6)
+    max_threads = info.get("max_threads", 0)
     codec = info.get("codec", "auto")
     range_ = info.get("range", "full")
     tile_rows_log2 = info.get("tile_rows", 0)
@@ -196,6 +197,7 @@ def _save(im, fp, filename, save_all=False):
         qmax,
         quality,
         speed,
+        max_threads,
         codec,
         range_,
         tile_rows_log2,

--- a/src/pillow_avif/AvifImagePlugin.py
+++ b/src/pillow_avif/AvifImagePlugin.py
@@ -16,6 +16,7 @@ except ImportError:
 # to Image.open (see https://github.com/python-pillow/Pillow/issues/569)
 DECODE_CODEC_CHOICE = "auto"
 CHROMA_UPSAMPLING = "auto"
+DECODE_MAX_THREADS = 0
 
 _VALID_AVIF_MODES = {"RGB", "RGBA"}
 
@@ -61,7 +62,7 @@ class AvifImageFile(ImageFile.ImageFile):
 
     def _open(self):
         self._decoder = _avif.AvifDecoder(
-            self.fp.read(), DECODE_CODEC_CHOICE, CHROMA_UPSAMPLING
+            self.fp.read(), DECODE_CODEC_CHOICE, CHROMA_UPSAMPLING, DECODE_MAX_THREADS
         )
 
         # Get info from decoder

--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -336,7 +336,7 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "IIsiiiissiiOOSSiSO",
+            "IIsiiiiissiiOOSSiSO",
             &width,
             &height,
             &subsampling,
@@ -344,6 +344,7 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
             &qmax,
             &quality,
             &speed,
+            &max_threads,
             &codec,
             &range,
             &tile_rows_log2,

--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -730,7 +730,7 @@ AvifDecoderNew(PyObject *self_, PyObject *args) {
 
     avifResult result;
 
-    if (!PyArg_ParseTuple(args, "Sss", &avif_bytes, &codec_str, &upsampling_str)) {
+    if (!PyArg_ParseTuple(args, "Sssi", &avif_bytes, &codec_str, &upsampling_str, &max_threads)) {
         return NULL;
     }
 


### PR DESCRIPTION
Although the Image.open API doesn't yet let you pass arguments nicely to the underlying decoder, it would be really nice to be able to configure the decoder's max_threads option via this plugin when I know that the image I am reading is an AVIF. Example:

decode_threads.py
```
import pillow_avif
from pillow_avif import _avif
from PIL import Image

if __name__ == "__main__":

    from pillow_avif import _avif

    orig = Image.open("tests/images/flower.jpg")
    orig.save("flower.avif", quality=80)

    with open("flower.avif", "rb") as f:
        decoder = _avif.AvifDecoder(f.read(), "auto", "auto", 4) # 4 is max_threads
        width, height, n_frames, mode, icc, exif, xmp = decoder.get_info()
        data, timescale, tsp_in_ts, dur_in_ts = decoder.get_frame(0)

        img = Image.frombytes(mode=mode, size=(width, height), data=data)
        img.save("foobar.jpg")
```

The default behavior is unchanged, max_threads is still 0 when you open an avif via Image.open(). Only when you drop down a layer can you configure this.

As with #49, maybe we should consider a more reasonable default value for the decoder's max_threads for the same reasons.

Reproduce:
```
conda activate foobar # This is some new empty conda environment
conda install -c conda-forge pillow 'libavif>=1.0.2' aom 'python=3.10.*' pillow
cd pillow-avif-plugin
pip install --no-deps .
python decode_threads.py
```