### PR TITLE
fix: macOS arm64 illegal instruction segmentation fault with aom encoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,6 @@ jobs:
           ${{ env.LIBAVIF_VERSION }}-${{ hashFiles('.github/workflows/*.sh', '.github/workflows/test.yml', 'depends/*') }}-${{ matrix.os }}
 
     - name: Install nasm
-      if: steps.build-cache.outputs.cache-hit != 'true'
       uses: ilammy/setup-nasm@v1
       with:
         version: 2.15.05

--- a/tests/test_file_avif.py
+++ b/tests/test_file_avif.py
@@ -584,6 +584,18 @@ class TestFileAvif:
         with Image.open("%s/tests/images/chimera-missing-pixi.avif" % CURR_DIR) as im:
             assert im.size == (480, 270)
 
+    @skip_unless_avif_encoder("aom")
+    def test_aom_optimizations(self):
+        im = hopper("RGB")
+        buf = BytesIO()
+        im.save(buf, format="AVIF", codec="aom", speed=1)
+
+    @skip_unless_avif_encoder("svt")
+    def test_svt_optimizations(self):
+        im = hopper("RGB")
+        buf = BytesIO()
+        im.save(buf, format="AVIF", codec="svt", speed=1)
+
 
 class TestAvifAnimation:
     @contextmanager

--- a/wheelbuild/config.sh
+++ b/wheelbuild/config.sh
@@ -229,7 +229,7 @@ function build_libavif {
     cmake --version
     if [ -n "$IS_MACOS" ] && [ "$PLAT" == "arm64" ]; then
         # SVT-AV1 NEON intrinsics require macOS 14
-        local macos_ver==$(sw_vers --productVersion | sed 's/\.[0-9]*//')
+        local macos_ver=$(sw_vers --productVersion | sed 's/\.[0-9]*//')
         if [ "$macos_ver" -gt "13" ]; then
             LIBAVIF_CMAKE_FLAGS+=(-DAVIF_CODEC_SVT=LOCAL)
         fi

--- a/wheelbuild/config.sh
+++ b/wheelbuild/config.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 CONFIG_DIR=$(abspath $(dirname "${BASH_SOURCE[0]}"))
 
 ARCHIVE_SDIR=pillow-avif-plugin-depends
-LIBAVIF_VERSION=e10e6d98e6d1dbcdd409859a924d1b607a1e06dc
+LIBAVIF_VERSION=02fc53e73d68dccacc54ce543b1be1e9b3236495
 RAV1E_VERSION=0.7.1
 CCACHE_VERSION=4.7.1
 SCCACHE_VERSION=0.3.0
@@ -270,7 +270,7 @@ EOF
     group_start "Download libavif source"
 
     fetch_unpack \
-        "https://github.com/AOMediaCodec/libavif/archive/$LIBAVIF_VERSION.tar.gz" \
+        "https://github.com/fdintino/libavif/archive/$LIBAVIF_VERSION.tar.gz" \
         "libavif-$LIBAVIF_VERSION.tar.gz"
 
     group_end

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -181,10 +181,10 @@ DEPS = {
     "libavif": {
         "url": (
             "https://github.com/fdintino/libavif/archive/"
-            "e10e6d98e6d1dbcdd409859a924d1b607a1e06dc.zip"
+            "02fc53e73d68dccacc54ce543b1be1e9b3236495.zip"
         ),
-        "filename": "libavif-e10e6d98e6d1dbcdd409859a924d1b607a1e06dc.zip",
-        "dir": "libavif-e10e6d98e6d1dbcdd409859a924d1b607a1e06dc",
+        "filename": "libavif-02fc53e73d68dccacc54ce543b1be1e9b3236495.zip",
+        "dir": "libavif-02fc53e73d68dccacc54ce543b1be1e9b3236495",
         "license": "LICENSE",
         "build": [
             cmd_mkdir("build.pillow"),


### PR DESCRIPTION
refs #59; will have issue reporter confirm that this fixes the issue after releasing.

This updates the libavif sha to incorporate the fix in AOMediaCodec/libavif#2265