### PR TITLE
chore: sync with changes from python-pillow/Pillow#5201

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Changes since 1.4.6 (unreleased)
 --------------------------------
 
+* **Fixed**: Convert AVIF irot and imir into EXIF orientation when decoding
+  an image, in `#70`_. EXIF orientation has been preserved by the encoder
+  since 1.4.2, which is when we started setting irot and imir. But if an AVIF
+  image with non-default irot or imir values was converted to another format,
+  its orientation would be lost.
+* **Fixed**: ``pillow_avif.AvifImagePlugin.CHROMA_UPSAMPLING`` is now actually
+  used when decoding an image, in `#70`_.
+* **Added**: Python 3.13 free-thread mode support (experimental).
 *  **CI**: Update libavif to 1.2.0 (`4eb0a40`_, 2025-03-05); publish wheels
    for python 3.13. See the table below for the current AVIF codec versions.
    Libraries whose versions have changed since the last pillow-avif-plugin
@@ -19,6 +27,7 @@ Changes since 1.4.6 (unreleased)
   rav1e        0.7.1
   ===========  ==========
 
+.. _#70: https://github.com/fdintino/pillow-avif-plugin/pull/70
 .. _4eb0a40: https://github.com/AOMediaCodec/libavif/commit/4eb0a40fb06612adf53650a14c692eaf62c068e6
 
 1.4.6 (Jul 14, 2024)

--- a/src/pillow_avif/AvifImagePlugin.py
+++ b/src/pillow_avif/AvifImagePlugin.py
@@ -95,13 +95,16 @@ class AvifImageFile(ImageFile.ImageFile):
 
         if exif_orientation != 1 or exif:
             exif_data = Image.Exif()
+            orientation_tag = next(
+                k for k, v in ExifTags.TAGS.items() if v == "Orientation"
+            )
             if exif:
                 exif_data.load(exif)
-                original_orientation = exif_data.get(ExifTags.Base.Orientation, 1)
+                original_orientation = exif_data.get(orientation_tag, 1)
             else:
                 original_orientation = 1
             if exif_orientation != original_orientation:
-                exif_data[ExifTags.Base.Orientation] = exif_orientation
+                exif_data[orientation_tag] = exif_orientation
                 exif = exif_data.tobytes()
         if exif:
             self.info["exif"] = exif

--- a/src/pillow_avif/AvifImagePlugin.py
+++ b/src/pillow_avif/AvifImagePlugin.py
@@ -16,10 +16,8 @@ except ImportError:
 # to Image.open (see https://github.com/python-pillow/Pillow/issues/569)
 DECODE_CODEC_CHOICE = "auto"
 CHROMA_UPSAMPLING = "auto"
+# Decoding is only affected by this for libavif **0.8.4** or greater.
 DEFAULT_MAX_THREADS = 0
-
-_VALID_AVIF_MODES = {"RGB", "RGBA"}
-
 
 if sys.version_info[0] == 2:
     text_type = unicode  # noqa
@@ -29,18 +27,12 @@ else:
 
 def _accept(prefix):
     if prefix[4:8] != b"ftyp":
-        return
-    coding_brands = (b"avif", b"avis")
-    container_brands = (b"mif1", b"msf1")
+        return False
     major_brand = prefix[8:12]
-    if major_brand in coding_brands:
-        if not SUPPORTED:
-            return (
-                "image file could not be identified because AVIF "
-                "support not installed"
-            )
-        return True
-    if major_brand in container_brands:
+    if major_brand in (
+        # coding brands
+        b"avif",
+        b"avis",
         # We accept files with AVIF container brands; we can't yet know if
         # the ftyp box has the correct compatible brands, but if it doesn't
         # then the plugin will raise a SyntaxError which Pillow will catch
@@ -48,66 +40,104 @@ def _accept(prefix):
         #
         # Also, because this file might not actually be an AVIF file, we
         # don't raise an error if AVIF support isn't properly compiled.
+        b"mif1",
+        b"msf1",
+    ):
+        if not SUPPORTED:
+            return (
+                "image file could not be identified because AVIF support not installed"
+            )
         return True
+    return False
 
 
 class AvifImageFile(ImageFile.ImageFile):
     format = "AVIF"
     format_description = "AVIF image"
-    __loaded = -1
-    __frame = 0
-
-    def load_seek(self, pos):
-        pass
+    __frame = -1
 
     def _open(self):
+        if not SUPPORTED:
+            msg = "image file could not be opened because AVIF support not installed"
+            raise SyntaxError(msg)
+
+        if DECODE_CODEC_CHOICE != "auto" and not _avif.decoder_codec_available(
+            DECODE_CODEC_CHOICE
+        ):
+            msg = "Invalid opening codec"
+            raise ValueError(msg)
         self._decoder = _avif.AvifDecoder(
             self.fp.read(), DECODE_CODEC_CHOICE, CHROMA_UPSAMPLING, DEFAULT_MAX_THREADS
         )
 
         # Get info from decoder
-        width, height, n_frames, mode, icc, exif, xmp = self._decoder.get_info()
-        self._size = width, height
-        self.n_frames = n_frames
+        (
+            width,
+            height,
+            self.n_frames,
+            mode,
+            icc,
+            exif,
+            exif_orientation,
+            xmp,
+        ) = self._decoder.get_info()
+        self._size = (width, height)
         self.is_animated = self.n_frames > 1
         try:
             self.mode = self.rawmode = mode
         except AttributeError:
             self._mode = self.rawmode = mode
-        self.tile = []
 
         if icc:
             self.info["icc_profile"] = icc
-        if exif:
-            self.info["exif"] = exif
         if xmp:
             self.info["xmp"] = xmp
+
+        if exif_orientation != 1 or exif:
+            exif_data = Image.Exif()
+            if exif:
+                exif_data.load(exif)
+                original_orientation = exif_data.get(ExifTags.Base.Orientation, 1)
+            else:
+                original_orientation = 1
+            if exif_orientation != original_orientation:
+                exif_data[ExifTags.Base.Orientation] = exif_orientation
+                exif = exif_data.tobytes()
+        if exif:
+            self.info["exif"] = exif
+        self.seek(0)
 
     def seek(self, frame):
         if not self._seek_check(frame):
             return
 
+        # Set tile
         self.__frame = frame
+        if hasattr(ImageFile, "_Tile"):
+            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 0, self.mode)]
+        else:
+            self.tile = [("raw", (0, 0) + self.size, 0, self.mode)]
 
     def load(self):
-        if self.__loaded != self.__frame:
+        if self.tile:
             # We need to load the image data for this frame
-            data, timescale, tsp_in_ts, dur_in_ts = self._decoder.get_frame(
-                self.__frame
-            )
-            timestamp = round(1000 * (tsp_in_ts / timescale))
-            duration = round(1000 * (dur_in_ts / timescale))
-            self.info["timestamp"] = timestamp
-            self.info["duration"] = duration
-            self.__loaded = self.__frame
+            (
+                data,
+                timescale,
+                pts_in_timescales,
+                duration_in_timescales,
+            ) = self._decoder.get_frame(self.__frame)
+            self.info["timestamp"] = round(1000 * (pts_in_timescales / timescale))
+            self.info["duration"] = round(1000 * (duration_in_timescales / timescale))
 
-            # Set tile
             if self.fp and self._exclusive_fp:
                 self.fp.close()
             self.fp = BytesIO(data)
-            self.tile = [("raw", (0, 0) + self.size, 0, self.rawmode)]
 
         return super(AvifImageFile, self).load()
+
+    def load_seek(self, pos):
+        pass
 
     def tell(self):
         return self.__frame
@@ -128,19 +158,21 @@ def _save(im, fp, filename, save_all=False):
     for ims in [im] + append_images:
         total += getattr(ims, "n_frames", 1)
 
-    is_single_frame = total == 1
-
     qmin = info.get("qmin", -1)
     qmax = info.get("qmax", -1)
     quality = info.get("quality", 75)
     if not isinstance(quality, int) or quality < 0 or quality > 100:
-        raise ValueError("Invalid quality setting")
+        msg = "Invalid quality setting"
+        raise ValueError(msg)
 
     duration = info.get("duration", 0)
     subsampling = info.get("subsampling", "4:2:0")
     speed = info.get("speed", 6)
     max_threads = info.get("max_threads", DEFAULT_MAX_THREADS)
     codec = info.get("codec", "auto")
+    if codec != "auto" and not _avif.encoder_codec_available(codec):
+        msg = "Invalid saving codec"
+        raise ValueError(msg)
     range_ = info.get("range", "full")
     tile_rows_log2 = info.get("tile_rows", 0)
     tile_cols_log2 = info.get("tile_cols", 0)
@@ -171,20 +203,21 @@ def _save(im, fp, filename, save_all=False):
         xmp = xmp.encode("utf-8")
 
     advanced = info.get("advanced")
-    if isinstance(advanced, dict):
-        advanced = tuple([k, v] for (k, v) in advanced.items())
     if advanced is not None:
+        if isinstance(advanced, dict):
+            advanced = tuple(advanced.items())
         try:
             advanced = tuple(advanced)
         except TypeError:
             invalid = True
         else:
-            invalid = all(isinstance(v, tuple) and len(v) == 2 for v in advanced)
+            invalid = any(not isinstance(v, tuple) or len(v) != 2 for v in advanced)
         if invalid:
-            raise ValueError(
+            msg = (
                 "advanced codec options must be a dict of key-value string "
                 "pairs or a series of key-value two-tuples"
             )
+            raise ValueError(msg)
         advanced = tuple(
             [(str(k).encode("utf-8"), str(v).encode("utf-8")) for k, v in advanced]
         )
@@ -214,8 +247,9 @@ def _save(im, fp, filename, save_all=False):
 
     # Add each frame
     frame_idx = 0
-    frame_dur = 0
+    frame_duration = 0
     cur_idx = im.tell()
+    is_single_frame = total == 1
     try:
         for ims in [im] + append_images:
             # Get # of frames in this image
@@ -228,7 +262,7 @@ def _save(im, fp, filename, save_all=False):
                 # Make sure image mode is supported
                 frame = ims
                 rawmode = ims.mode
-                if ims.mode not in _VALID_AVIF_MODES:
+                if ims.mode not in {"RGB", "RGBA"}:
                     alpha = (
                         "A" in ims.mode
                         or "a" in ims.mode
@@ -243,14 +277,14 @@ def _save(im, fp, filename, save_all=False):
 
                 # Update frame duration
                 if isinstance(duration, (list, tuple)):
-                    frame_dur = duration[frame_idx]
+                    frame_duration = duration[frame_idx]
                 else:
-                    frame_dur = duration
+                    frame_duration = duration
 
                 # Append the frame to the animation encoder
                 enc.add(
                     frame.tobytes("raw", rawmode),
-                    frame_dur,
+                    frame_duration,
                     frame.size[0],
                     frame.size[1],
                     rawmode,
@@ -269,7 +303,8 @@ def _save(im, fp, filename, save_all=False):
     # Get the final output from the encoder
     data = enc.finish()
     if data is None:
-        raise OSError("cannot write file as AVIF (encoder returned None)")
+        msg = "cannot write file as AVIF (encoder returned None)"
+        raise OSError(msg)
 
     fp.write(data)
 

--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -9,20 +9,6 @@
 #define AVIF_CHROMA_UPSAMPLING_FASTEST AVIF_CHROMA_UPSAMPLING_NEAREST
 #endif
 
-typedef struct {
-    avifPixelFormat subsampling;
-    int qmin;
-    int qmax;
-    int quality;
-    int speed;
-    avifCodecChoice codec;
-    avifRange range;
-    avifBool alpha_premultiplied;
-    int tile_rows_log2;
-    int tile_cols_log2;
-    avifBool autotiling;
-} avifEncOptions;
-
 // Encoder type
 typedef struct {
     PyObject_HEAD
@@ -31,7 +17,7 @@ typedef struct {
     PyObject *icc_bytes;
     PyObject *exif_bytes;
     PyObject *xmp_bytes;
-    int frame_index;
+    int first_frame;
 } AvifEncoderObject;
 
 static PyTypeObject AvifEncoder_Type;
@@ -41,7 +27,7 @@ typedef struct {
     PyObject_HEAD
     avifDecoder *decoder;
     PyObject *data;
-    char *mode;
+    avifChromaUpsampling upsampling;
 } AvifDecoderObject;
 
 static PyTypeObject AvifDecoder_Type;
@@ -101,6 +87,7 @@ error:
     goto done;
 }
 
+#if AVIF_VERSION < 1000000
 static int
 normalize_quantize_value(int qvalue) {
     if (qvalue < AVIF_QUANTIZER_BEST_QUALITY) {
@@ -111,6 +98,7 @@ normalize_quantize_value(int qvalue) {
         return qvalue;
     }
 }
+#endif
 
 static int
 normalize_tiles_log2(int value) {
@@ -139,120 +127,100 @@ exc_type_for_avif_result(avifResult result) {
     }
 }
 
+static uint8_t
+irot_imir_to_exif_orientation(const avifImage *image) {
+    uint8_t axis;
+#if AVIF_VERSION_MAJOR >= 1
+    axis = image->imir.axis;
+#else
+    axis = image->imir.mode;
+#endif
+    int imir = image->transformFlags & AVIF_TRANSFORM_IMIR;
+    int irot = image->transformFlags & AVIF_TRANSFORM_IROT;
+    if (irot) {
+        uint8_t angle = image->irot.angle;
+        if (angle == 1) {
+            if (imir) {
+                return axis ? 7   // 90 degrees anti-clockwise then swap left and right.
+                            : 5;  // 90 degrees anti-clockwise then swap top and bottom.
+            }
+            return 6;  // 90 degrees anti-clockwise.
+        }
+        if (angle == 2) {
+            if (imir) {
+                return axis
+                           ? 4   // 180 degrees anti-clockwise then swap left and right.
+                           : 2;  // 180 degrees anti-clockwise then swap top and bottom.
+            }
+            return 3;  // 180 degrees anti-clockwise.
+        }
+        if (angle == 3) {
+            if (imir) {
+                return axis
+                           ? 5   // 270 degrees anti-clockwise then swap left and right.
+                           : 7;  // 270 degrees anti-clockwise then swap top and bottom.
+            }
+            return 8;  // 270 degrees anti-clockwise.
+        }
+    }
+    if (imir) {
+        return axis ? 2   // Swap left and right.
+                    : 4;  // Swap top and bottom.
+    }
+    return 1;  // Default orientation ("top-left", no-op).
+}
+
 static void
 exif_orientation_to_irot_imir(avifImage *image, int orientation) {
-    const avifTransformFlags otherFlags =
-        image->transformFlags & ~(AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR);
-
-    //
     // Mapping from Exif orientation as defined in JEITA CP-3451C section 4.6.4.A
     // Orientation to irot and imir boxes as defined in HEIF ISO/IEC 28002-12:2021
     // sections 6.5.10 and 6.5.12.
     switch (orientation) {
-        case 1:  // The 0th row is at the visual top of the image, and the 0th column is
-                 // the visual left-hand side.
-            image->transformFlags = otherFlags;
-            image->irot.angle = 0;  // ignored
-#if AVIF_VERSION_MAJOR >= 1
-            image->imir.axis = 0;   // ignored
-#else
-            image->imir.mode = 0;   // ignored
-#endif
-            return;
         case 2:  // The 0th row is at the visual top of the image, and the 0th column is
                  // the visual right-hand side.
-            image->transformFlags = otherFlags | AVIF_TRANSFORM_IMIR;
-            image->irot.angle = 0;  // ignored
+            image->transformFlags |= AVIF_TRANSFORM_IMIR;
 #if AVIF_VERSION_MAJOR >= 1
             image->imir.axis = 1;
 #else
             image->imir.mode = 1;
 #endif
-            return;
+            break;
         case 3:  // The 0th row is at the visual bottom of the image, and the 0th column
                  // is the visual right-hand side.
-            image->transformFlags = otherFlags | AVIF_TRANSFORM_IROT;
+            image->transformFlags |= AVIF_TRANSFORM_IROT;
             image->irot.angle = 2;
-#if AVIF_VERSION_MAJOR >= 1
-            image->imir.axis = 0;  // ignored
-#else
-            image->imir.mode = 0;  // ignored
-#endif
-            return;
+            break;
         case 4:  // The 0th row is at the visual bottom of the image, and the 0th column
                  // is the visual left-hand side.
-            image->transformFlags = otherFlags | AVIF_TRANSFORM_IMIR;
-            image->irot.angle = 0;  // ignored
-#if AVIF_VERSION_MAJOR >= 1
-            image->imir.axis = 0;
-#else
-            image->imir.mode = 0;
-#endif
-            return;
+            image->transformFlags |= AVIF_TRANSFORM_IMIR;
+            break;
         case 5:  // The 0th row is the visual left-hand side of the image, and the 0th
                  // column is the visual top.
-            image->transformFlags =
-                otherFlags | AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR;
+            image->transformFlags |= AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR;
             image->irot.angle = 1;  // applied before imir according to MIAF spec
                                     // ISO/IEC 28002-12:2021 - section 7.3.6.7
-#if AVIF_VERSION_MAJOR >= 1
-            image->imir.axis = 0;
-#else
-            image->imir.mode = 0;
-#endif
-            return;
+            break;
         case 6:  // The 0th row is the visual right-hand side of the image, and the 0th
                  // column is the visual top.
-            image->transformFlags = otherFlags | AVIF_TRANSFORM_IROT;
+            image->transformFlags |= AVIF_TRANSFORM_IROT;
             image->irot.angle = 3;
-#if AVIF_VERSION_MAJOR >= 1
-            image->imir.axis = 0;  // ignored
-#else
-            image->imir.mode = 0;  // ignored
-#endif
-            return;
+            break;
         case 7:  // The 0th row is the visual right-hand side of the image, and the 0th
                  // column is the visual bottom.
-            image->transformFlags =
-                otherFlags | AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR;
+            image->transformFlags |= AVIF_TRANSFORM_IROT | AVIF_TRANSFORM_IMIR;
             image->irot.angle = 3;  // applied before imir according to MIAF spec
                                     // ISO/IEC 28002-12:2021 - section 7.3.6.7
-#if AVIF_VERSION_MAJOR >= 1
-            image->imir.axis = 0;
-#else
-            image->imir.mode = 0;
-#endif
-            return;
+            break;
         case 8:  // The 0th row is the visual left-hand side of the image, and the 0th
                  // column is the visual bottom.
-            image->transformFlags = otherFlags | AVIF_TRANSFORM_IROT;
+            image->transformFlags |= AVIF_TRANSFORM_IROT;
             image->irot.angle = 1;
-#if AVIF_VERSION_MAJOR >= 1
-            image->imir.axis = 0;  // ignored
-#else
-            image->imir.mode = 0;  // ignored
-#endif
-            return;
-        default:  // reserved
             break;
     }
-
-    // The orientation tag is not mandatory (only recommended) according to JEITA
-    // CP-3451C section 4.6.8.A. The default value is 1 if the orientation tag is
-    // missing, meaning:
-    //   The 0th row is at the visual top of the image, and the 0th column is the visual
-    //   left-hand side.
-    image->transformFlags = otherFlags;
-    image->irot.angle = 0;  // ignored
-#if AVIF_VERSION_MAJOR >= 1
-    image->imir.axis = 0;   // ignored
-#else
-    image->imir.mode = 0;   // ignored
-#endif
 }
 
 static int
-_codec_available(const char *name, uint32_t flags) {
+_codec_available(const char *name, avifCodecFlags flags) {
     avifCodecChoice codec = avifCodecChoiceFromName(name);
     if (codec == AVIF_CODEC_CHOICE_AUTO) {
         return 0;
@@ -281,59 +249,76 @@ _encoder_codec_available(PyObject *self, PyObject *args) {
     return PyBool_FromLong(is_available);
 }
 
-static void
+#if AVIF_VERSION >= 80200
+static int
 _add_codec_specific_options(avifEncoder *encoder, PyObject *opts) {
     Py_ssize_t i, size;
     PyObject *keyval, *py_key, *py_val;
-    char *key, *val;
     if (!PyTuple_Check(opts)) {
-        return;
+        PyErr_SetString(PyExc_ValueError, "Invalid advanced codec options");
+        return 1;
     }
     size = PyTuple_GET_SIZE(opts);
 
     for (i = 0; i < size; i++) {
         keyval = PyTuple_GetItem(opts, i);
         if (!PyTuple_Check(keyval) || PyTuple_GET_SIZE(keyval) != 2) {
-            return;
+            PyErr_SetString(PyExc_ValueError, "Invalid advanced codec options");
+            return 1;
         }
         py_key = PyTuple_GetItem(keyval, 0);
         py_val = PyTuple_GetItem(keyval, 1);
         if (!PyBytes_Check(py_key) || !PyBytes_Check(py_val)) {
-            return;
+            PyErr_SetString(PyExc_ValueError, "Invalid advanced codec options");
+            return 1;
         }
-        key = PyBytes_AsString(py_key);
-        val = PyBytes_AsString(py_val);
-        avifEncoderSetCodecSpecificOption(encoder, key, val);
+        const char *key = PyBytes_AsString(py_key);
+        const char *val = PyBytes_AsString(py_val);
+        if (key == NULL || val == NULL) {
+            PyErr_SetString(PyExc_ValueError, "Invalid advanced codec options");
+            return 1;
+        }
+
+        avifResult result = avifEncoderSetCodecSpecificOption(encoder, key, val);
+        if (result != AVIF_RESULT_OK) {
+            PyErr_Format(
+                exc_type_for_avif_result(result),
+                "Setting advanced codec options failed: %s",
+                avifResultToString(result));
+            return 1;
+        }
     }
+    return 0;
 }
+#endif
 
 // Encoder functions
 PyObject *
 AvifEncoderNew(PyObject *self_, PyObject *args) {
     unsigned int width, height;
-    avifEncOptions enc_options;
     AvifEncoderObject *self = NULL;
     avifEncoder *encoder = NULL;
 
-    char *subsampling = "4:2:0";
-    int qmin = AVIF_QUANTIZER_BEST_QUALITY;  // =0
-    int qmax = 10;                           // "High Quality", but not lossless
-    int quality = 75;
-    int speed = 8;
-    int exif_orientation = 0;
-    int max_threads = default_max_threads;
+    char *subsampling;
+    int quality;
+    int qmin;
+    int qmax;
+    int speed;
+    int exif_orientation;
+    int max_threads;
     PyObject *icc_bytes;
     PyObject *exif_bytes;
     PyObject *xmp_bytes;
-    PyObject *alpha_premultiplied = NULL;
-    PyObject *autotiling = NULL;
-    int tile_rows_log2 = 0;
-    int tile_cols_log2 = 0;
+    PyObject *alpha_premultiplied;
+    PyObject *autotiling;
+    int tile_rows_log2;
+    int tile_cols_log2;
 
-    char *codec = "auto";
-    char *range = "full";
+    char *codec;
+    char *range;
 
     PyObject *advanced;
+    int error = 0;
 
     if (!PyArg_ParseTuple(
             args,
@@ -360,182 +345,220 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
         return NULL;
     }
 
-    if (strcmp(subsampling, "4:0:0") == 0) {
-        enc_options.subsampling = AVIF_PIXEL_FORMAT_YUV400;
-    } else if (strcmp(subsampling, "4:2:0") == 0) {
-        enc_options.subsampling = AVIF_PIXEL_FORMAT_YUV420;
-    } else if (strcmp(subsampling, "4:2:2") == 0) {
-        enc_options.subsampling = AVIF_PIXEL_FORMAT_YUV422;
-    } else if (strcmp(subsampling, "4:4:4") == 0) {
-        enc_options.subsampling = AVIF_PIXEL_FORMAT_YUV444;
-    } else {
-        PyErr_Format(PyExc_ValueError, "Invalid subsampling: %s", subsampling);
-        return NULL;
+    // Create a new animation encoder and picture frame
+    avifImage *image = avifImageCreateEmpty();
+    if (image == NULL) {
+        PyErr_SetString(PyExc_ValueError, "Image creation failed");
+        error = 1;
+        goto end;
     }
 
-    if (qmin == -1 || qmax == -1) {
-#if AVIF_VERSION >= 1000000
-        enc_options.qmin = -1;
-        enc_options.qmax = -1;
-#else
-        enc_options.qmin = normalize_quantize_value(64 - quality);
-        enc_options.qmax = normalize_quantize_value(100 - quality);
-#endif
+    // Set these in advance so any upcoming RGB -> YUV use the proper coefficients
+    if (strcmp(range, "full") == 0) {
+        image->yuvRange = AVIF_RANGE_FULL;
+    } else if (strcmp(range, "limited") == 0) {
+        image->yuvRange = AVIF_RANGE_LIMITED;
     } else {
-        enc_options.qmin = normalize_quantize_value(qmin);
-        enc_options.qmax = normalize_quantize_value(qmax);
+        PyErr_SetString(PyExc_ValueError, "Invalid range");
+        error = 1;
+        goto end;
     }
-    enc_options.quality = quality;
+    if (strcmp(subsampling, "4:0:0") == 0) {
+        image->yuvFormat = AVIF_PIXEL_FORMAT_YUV400;
+    } else if (strcmp(subsampling, "4:2:0") == 0) {
+        image->yuvFormat = AVIF_PIXEL_FORMAT_YUV420;
+    } else if (strcmp(subsampling, "4:2:2") == 0) {
+        image->yuvFormat = AVIF_PIXEL_FORMAT_YUV422;
+    } else if (strcmp(subsampling, "4:4:4") == 0) {
+        image->yuvFormat = AVIF_PIXEL_FORMAT_YUV444;
+    } else {
+        PyErr_Format(PyExc_ValueError, "Invalid subsampling: %s", subsampling);
+        error = 1;
+        goto end;
+    }
+
+    // Validate canvas dimensions
+    if (width == 0 || height == 0) {
+        PyErr_SetString(PyExc_ValueError, "invalid canvas dimensions");
+        error = 1;
+        goto end;
+    }
+    image->width = width;
+    image->height = height;
+
+    image->depth = 8;
+#if AVIF_VERSION >= 90000
+    image->alphaPremultiplied = alpha_premultiplied == Py_True ? AVIF_TRUE : AVIF_FALSE;
+#endif
+
+    encoder = avifEncoderCreate();
+    if (!encoder) {
+        PyErr_SetString(PyExc_MemoryError, "Can't allocate encoder");
+        error = 1;
+        goto end;
+    }
+
+    if (max_threads == 0) {
+        if (default_max_threads == 0) {
+            init_max_threads();
+        }
+        max_threads = default_max_threads;
+    }
+
+    int is_aom_encode = strcmp(codec, "aom") == 0 ||
+                        (strcmp(codec, "auto") == 0 &&
+                         _codec_available("aom", AVIF_CODEC_FLAG_CAN_ENCODE));
+    encoder->maxThreads = is_aom_encode && max_threads > 64 ? 64 : max_threads;
+
+#if AVIF_VERSION < 1000000
+    if (qmin != -1 && qmax != -1) {
+        encoder->minQuantizer = qmin;
+        encoder->maxQuantizer = qmax;
+    } else {
+        encoder->minQuantizer = normalize_quantize_value(64 - quality);
+        encoder->maxQuantizer = normalize_quantize_value(100 - quality);
+    }
+#else
+    encoder->quality = quality;
+#endif
+
+    if (strcmp(codec, "auto") == 0) {
+        encoder->codecChoice = AVIF_CODEC_CHOICE_AUTO;
+    } else {
+        encoder->codecChoice = avifCodecChoiceFromName(codec);
+    }
 
     if (speed < AVIF_SPEED_SLOWEST) {
         speed = AVIF_SPEED_SLOWEST;
     } else if (speed > AVIF_SPEED_FASTEST) {
         speed = AVIF_SPEED_FASTEST;
     }
-    enc_options.speed = speed;
-
-    if (strcmp(codec, "auto") == 0) {
-        enc_options.codec = AVIF_CODEC_CHOICE_AUTO;
-    } else {
-        enc_options.codec = avifCodecChoiceFromName(codec);
-        if (enc_options.codec == AVIF_CODEC_CHOICE_AUTO) {
-            PyErr_Format(PyExc_ValueError, "Invalid codec: %s", codec);
-            return NULL;
-        } else {
-            const char *codec_name =
-                avifCodecName(enc_options.codec, AVIF_CODEC_FLAG_CAN_ENCODE);
-            if (codec_name == NULL) {
-                PyErr_Format(PyExc_ValueError, "AV1 Codec cannot encode: %s", codec);
-                return NULL;
-            }
-        }
-    }
-
-    if (strcmp(range, "full") == 0) {
-        enc_options.range = AVIF_RANGE_FULL;
-    } else if (strcmp(range, "limited") == 0) {
-        enc_options.range = AVIF_RANGE_LIMITED;
-    } else {
-        PyErr_SetString(PyExc_ValueError, "Invalid range");
-        return NULL;
-    }
-
-    // Validate canvas dimensions
-    if (width <= 0 || height <= 0) {
-        PyErr_SetString(PyExc_ValueError, "invalid canvas dimensions");
-        return NULL;
-    }
-
-    enc_options.tile_rows_log2 = normalize_tiles_log2(tile_rows_log2);
-    enc_options.tile_cols_log2 = normalize_tiles_log2(tile_cols_log2);
-
-    if (alpha_premultiplied == Py_True) {
-        enc_options.alpha_premultiplied = AVIF_TRUE;
-    } else {
-        enc_options.alpha_premultiplied = AVIF_FALSE;
-    }
-
-    enc_options.autotiling = (autotiling == Py_True) ? AVIF_TRUE : AVIF_FALSE;
-
-    // Create a new animation encoder and picture frame
-    self = PyObject_New(AvifEncoderObject, &AvifEncoder_Type);
-    if (self) {
-        self->icc_bytes = NULL;
-        self->exif_bytes = NULL;
-        self->xmp_bytes = NULL;
-
-        encoder = avifEncoderCreate();
-
-        if (max_threads == 0) {
-            if (default_max_threads == 0) {
-                init_max_threads();
-            }
-            max_threads = default_max_threads;
-        }
-
-        int is_aom_encode = strcmp(codec, "aom") == 0 ||
-                            (strcmp(codec, "auto") == 0 &&
-                             _codec_available("aom", AVIF_CODEC_FLAG_CAN_ENCODE));
-
-        encoder->maxThreads = is_aom_encode && max_threads > 64 ? 64 : max_threads;
-#if AVIF_VERSION >= 1000000
-        if (enc_options.qmin != -1 && enc_options.qmax != -1) {
-            encoder->minQuantizer = enc_options.qmin;
-            encoder->maxQuantizer = enc_options.qmax;
-        } else {
-            encoder->quality = enc_options.quality;
-        }
-#else
-        encoder->minQuantizer = enc_options.qmin;
-        encoder->maxQuantizer = enc_options.qmax;
-#endif
-        encoder->codecChoice = enc_options.codec;
-        encoder->speed = enc_options.speed;
-        encoder->timescale = (uint64_t)1000;
-        encoder->tileRowsLog2 = enc_options.tile_rows_log2;
-        encoder->tileColsLog2 = enc_options.tile_cols_log2;
+    encoder->speed = speed;
+    encoder->timescale = (uint64_t)1000;
 
 #if AVIF_VERSION >= 110000
-        encoder->autoTiling = enc_options.autotiling;
+    if (PyObject_IsTrue(autotiling)) {
+        encoder->autoTiling = AVIF_TRUE;
+    } else {
+        encoder->autoTiling = AVIF_FALSE;
+        encoder->tileRowsLog2 = normalize_tiles_log2(tile_rows_log2);
+        encoder->tileColsLog2 = normalize_tiles_log2(tile_cols_log2);
+    }
+#else
+    encoder->tileRowsLog2 = normalize_tiles_log2(tile_rows_log2);
+    encoder->tileColsLog2 = normalize_tiles_log2(tile_cols_log2);
 #endif
 
+    if (advanced != Py_None) {
 #if AVIF_VERSION >= 80200
-        _add_codec_specific_options(encoder, advanced);
+        if (_add_codec_specific_options(encoder, advanced)) {
+            error = 1;
+            goto end;
+        }
+#else
+        PyErr_SetString(
+            PyExc_ValueError, "Advanced codec options require libavif >= 0.8.2");
+        error = 1;
+        goto end;
 #endif
+    }
 
-        self->encoder = encoder;
+    self = PyObject_New(AvifEncoderObject, &AvifEncoder_Type);
+    if (!self) {
+        PyErr_SetString(PyExc_RuntimeError, "could not create encoder object");
+        error = 1;
+        goto end;
+    }
+    self->first_frame = 1;
+    self->icc_bytes = NULL;
+    self->exif_bytes = NULL;
+    self->xmp_bytes = NULL;
 
-        avifImage *image = avifImageCreateEmpty();
-        // Set these in advance so any upcoming RGB -> YUV use the proper coefficients
-        image->yuvRange = enc_options.range;
-        image->yuvFormat = enc_options.subsampling;
+    avifResult result;
+    if (PyBytes_GET_SIZE(icc_bytes)) {
+        self->icc_bytes = icc_bytes;
+        Py_INCREF(icc_bytes);
+        result = avifImageSetProfileICC(
+            image,
+            (uint8_t *)PyBytes_AS_STRING(icc_bytes),
+            PyBytes_GET_SIZE(icc_bytes));
+        if (result != AVIF_RESULT_OK) {
+            PyErr_Format(
+                exc_type_for_avif_result(result),
+                "Setting ICC profile failed: %s",
+                avifResultToString(result));
+            error = 1;
+            goto end;
+        }
+        // colorPrimaries and transferCharacteristics are ignored when an ICC
+        // profile is present, so set them to UNSPECIFIED.
         image->colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
         image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED;
-        image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
-        image->width = width;
-        image->height = height;
-        image->depth = 8;
-#if AVIF_VERSION >= 90000
-        image->alphaPremultiplied = enc_options.alpha_premultiplied;
-#endif
-
-        if (PyBytes_GET_SIZE(icc_bytes)) {
-            self->icc_bytes = icc_bytes;
-            Py_INCREF(icc_bytes);
-            avifImageSetProfileICC(
-                image,
-                (uint8_t *)PyBytes_AS_STRING(icc_bytes),
-                PyBytes_GET_SIZE(icc_bytes));
-        } else {
-            image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
-            image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
-        }
-
-        if (PyBytes_GET_SIZE(exif_bytes)) {
-            self->exif_bytes = exif_bytes;
-            Py_INCREF(exif_bytes);
-            avifImageSetMetadataExif(
-                image,
-                (uint8_t *)PyBytes_AS_STRING(exif_bytes),
-                PyBytes_GET_SIZE(exif_bytes));
-        }
-        if (PyBytes_GET_SIZE(xmp_bytes)) {
-            self->xmp_bytes = xmp_bytes;
-            Py_INCREF(xmp_bytes);
-            avifImageSetMetadataXMP(
-                image,
-                (uint8_t *)PyBytes_AS_STRING(xmp_bytes),
-                PyBytes_GET_SIZE(xmp_bytes));
-        }
-        exif_orientation_to_irot_imir(image, exif_orientation);
-
-        self->image = image;
-        self->frame_index = -1;
-
-        return (PyObject *)self;
+    } else {
+        image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
+        image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
     }
-    PyErr_SetString(PyExc_RuntimeError, "could not create encoder object");
-    return NULL;
+    image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
+
+    if (PyBytes_GET_SIZE(exif_bytes)) {
+        self->exif_bytes = exif_bytes;
+        Py_INCREF(exif_bytes);
+        result = avifImageSetMetadataExif(
+            image,
+            (uint8_t *)PyBytes_AS_STRING(exif_bytes),
+            PyBytes_GET_SIZE(exif_bytes));
+        if (result != AVIF_RESULT_OK) {
+            PyErr_Format(
+                exc_type_for_avif_result(result),
+                "Setting EXIF data failed: %s",
+                avifResultToString(result));
+            error = 1;
+            goto end;
+        }
+    }
+
+    if (PyBytes_GET_SIZE(xmp_bytes)) {
+        self->xmp_bytes = xmp_bytes;
+        Py_INCREF(xmp_bytes);
+        result = avifImageSetMetadataXMP(
+            image,
+            (uint8_t *)PyBytes_AS_STRING(xmp_bytes),
+            PyBytes_GET_SIZE(xmp_bytes));
+        if (result != AVIF_RESULT_OK) {
+            PyErr_Format(
+                exc_type_for_avif_result(result),
+                "Setting XMP data failed: %s",
+                avifResultToString(result));
+            error = 1;
+            goto end;
+        }
+    }
+
+    if (exif_orientation) {
+        exif_orientation_to_irot_imir(image, exif_orientation);
+    }
+
+    self->image = image;
+    self->encoder = encoder;
+
+end:
+    if (error) {
+        if (image) {
+            avifImageDestroy(image);
+        }
+        if (encoder) {
+            avifEncoderDestroy(encoder);
+        }
+        if (self) {
+            Py_XDECREF(self->icc_bytes);
+            Py_XDECREF(self->exif_bytes);
+            Py_XDECREF(self->xmp_bytes);
+            PyObject_Del(self);
+        }
+        return NULL;
+    }
+
+    return (PyObject *)self;
 }
 
 PyObject *
@@ -561,10 +584,8 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
     unsigned int height;
     char *mode;
     PyObject *is_single_frame = NULL;
-    PyObject *ret = Py_None;
+    int error = 0;
 
-    int is_first_frame;
-    int channels;
     avifRGBImage rgb;
     avifResult result;
 
@@ -585,9 +606,7 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
         return NULL;
     }
 
-    is_first_frame = (self->frame_index == -1);
-
-    if ((image->width != width) || (image->height != height)) {
+    if (image->width != width || image->height != height) {
         PyErr_Format(
             PyExc_ValueError,
             "Image sequence dimensions mismatch, %ux%u != %ux%u",
@@ -598,12 +617,19 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
         return NULL;
     }
 
-    if (is_first_frame) {
-        // If we don't have an image populated with yuv planes, this is the first frame
+    if (self->first_frame) {
+        // If we don't have an image populated with yuv planes, this is the first
+        // frame
         frame = image;
     } else {
         frame = avifImageCreateEmpty();
+        if (image == NULL) {
+            PyErr_SetString(PyExc_ValueError, "Image creation failed");
+            return NULL;
+        }
 
+        frame->width = width;
+        frame->height = height;
         frame->colorPrimaries = image->colorPrimaries;
         frame->transferCharacteristics = image->transferCharacteristics;
         frame->matrixCoefficients = image->matrixCoefficients;
@@ -615,82 +641,82 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
 #endif
     }
 
-    frame->width = width;
-    frame->height = height;
-
-    memset(&rgb, 0, sizeof(avifRGBImage));
-
     avifRGBImageSetDefaults(&rgb, frame);
-    rgb.depth = 8;
 
     if (strcmp(mode, "RGBA") == 0) {
         rgb.format = AVIF_RGB_FORMAT_RGBA;
-        channels = 4;
     } else {
         rgb.format = AVIF_RGB_FORMAT_RGB;
-        channels = 3;
     }
 
-    avifRGBImageAllocatePixels(&rgb);
+    result = avifRGBImageAllocatePixels(&rgb);
+    if (result != AVIF_RESULT_OK) {
+        PyErr_Format(
+            exc_type_for_avif_result(result),
+            "Pixel allocation failed: %s",
+            avifResultToString(result));
+        error = 1;
+        goto end;
+    }
 
     if (rgb.rowBytes * rgb.height != size) {
         PyErr_Format(
             PyExc_RuntimeError,
-            "rgb data is incorrect size: %u * %u (%u) != %zd",
+            "rgb data has incorrect size: %u * %u (%u) != %u",
             rgb.rowBytes,
             rgb.height,
             rgb.rowBytes * rgb.height,
             size);
-        ret = NULL;
+        error = 1;
         goto end;
     }
 
     // rgb.pixels is safe for writes
     memcpy(rgb.pixels, rgb_bytes, size);
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     result = avifImageRGBToYUV(frame, &rgb);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
             exc_type_for_avif_result(result),
             "Conversion to YUV failed: %s",
             avifResultToString(result));
-        ret = NULL;
+        error = 1;
         goto end;
     }
 
-    uint32_t addImageFlags = AVIF_ADD_IMAGE_FLAG_NONE;
-    if (PyObject_IsTrue(is_single_frame)) {
-        addImageFlags |= AVIF_ADD_IMAGE_FLAG_SINGLE;
-    }
+    uint32_t addImageFlags = PyObject_IsTrue(is_single_frame)
+                                 ? AVIF_ADD_IMAGE_FLAG_SINGLE
+                                 : AVIF_ADD_IMAGE_FLAG_NONE;
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     result = avifEncoderAddImage(encoder, frame, duration, addImageFlags);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
             exc_type_for_avif_result(result),
             "Failed to encode image: %s",
             avifResultToString(result));
-        ret = NULL;
+        error = 1;
         goto end;
     }
 
 end:
-    avifRGBImageFreePixels(&rgb);
-    if (!is_first_frame) {
+    if (&rgb) {
+        avifRGBImageFreePixels(&rgb);
+    }
+    if (!self->first_frame) {
         avifImageDestroy(frame);
     }
 
-    if (ret == Py_None) {
-        self->frame_index++;
-        Py_RETURN_NONE;
-    } else {
-        return ret;
+    if (error) {
+        return NULL;
     }
+    self->first_frame = 0;
+    Py_RETURN_NONE;
 }
 
 PyObject *
@@ -701,9 +727,9 @@ _encoder_finish(AvifEncoderObject *self) {
     avifResult result;
     PyObject *ret = NULL;
 
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     result = avifEncoderFinish(encoder, &raw);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
@@ -726,6 +752,7 @@ PyObject *
 AvifDecoderNew(PyObject *self_, PyObject *args) {
     PyObject *avif_bytes;
     AvifDecoderObject *self = NULL;
+    avifDecoder *decoder;
 
     char *upsampling_str;
     char *codec_str;
@@ -735,7 +762,8 @@ AvifDecoderNew(PyObject *self_, PyObject *args) {
 
     avifResult result;
 
-    if (!PyArg_ParseTuple(args, "Sssi", &avif_bytes, &codec_str, &upsampling_str, &max_threads)) {
+    if (!PyArg_ParseTuple(
+            args, "Sssi", &avif_bytes, &codec_str, &upsampling_str, &max_threads)) {
         return NULL;
     }
 
@@ -758,17 +786,6 @@ AvifDecoderNew(PyObject *self_, PyObject *args) {
         codec = AVIF_CODEC_CHOICE_AUTO;
     } else {
         codec = avifCodecChoiceFromName(codec_str);
-        if (codec == AVIF_CODEC_CHOICE_AUTO) {
-            PyErr_Format(PyExc_ValueError, "Invalid codec: %s", codec_str);
-            return NULL;
-        } else {
-            const char *codec_name = avifCodecName(codec, AVIF_CODEC_FLAG_CAN_DECODE);
-            if (codec_name == NULL) {
-                PyErr_Format(
-                    PyExc_ValueError, "AV1 Codec cannot decode: %s", codec_str);
-                return NULL;
-            }
-        }
     }
 
     self = PyObject_New(AvifDecoderObject, &AvifDecoder_Type);
@@ -776,12 +793,16 @@ AvifDecoderNew(PyObject *self_, PyObject *args) {
         PyErr_SetString(PyExc_RuntimeError, "could not create decoder object");
         return NULL;
     }
-    self->decoder = NULL;
 
-    Py_INCREF(avif_bytes);
-    self->data = avif_bytes;
+    self->upsampling = upsampling;
 
-    self->decoder = avifDecoderCreate();
+    decoder = avifDecoderCreate();
+    if (!decoder) {
+        PyErr_SetString(PyExc_MemoryError, "Can't allocate decoder");
+        PyObject_Del(self);
+        return NULL;
+    }
+
 #if AVIF_VERSION >= 80400
     if (max_threads == 0) {
         if (default_max_threads == 0) {
@@ -789,41 +810,50 @@ AvifDecoderNew(PyObject *self_, PyObject *args) {
         }
         max_threads = default_max_threads;
     }
-    self->decoder->maxThreads = max_threads;
+    decoder->maxThreads = max_threads;
 #endif
 #if AVIF_VERSION >= 90200
     // Turn off libavif's 'clap' (clean aperture) property validation.
-    self->decoder->strictFlags &= ~AVIF_STRICT_CLAP_VALID;
+    decoder->strictFlags &= ~AVIF_STRICT_CLAP_VALID;
     // Allow the PixelInformationProperty ('pixi') to be missing in AV1 image
     // items. libheif v1.11.0 and older does not add the 'pixi' item property to
     // AV1 image items.
-    self->decoder->strictFlags &= ~AVIF_STRICT_PIXI_REQUIRED;
+    decoder->strictFlags &= ~AVIF_STRICT_PIXI_REQUIRED;
 #endif
-    self->decoder->codecChoice = codec;
+    decoder->codecChoice = codec;
 
-    avifDecoderSetIOMemory(
-        self->decoder,
-        (uint8_t *)PyBytes_AS_STRING(self->data),
-        PyBytes_GET_SIZE(self->data));
+    Py_INCREF(avif_bytes);
 
-    result = avifDecoderParse(self->decoder);
+    result = avifDecoderSetIOMemory(
+        decoder,
+        (uint8_t *)PyBytes_AS_STRING(avif_bytes),
+        PyBytes_GET_SIZE(avif_bytes));
 
+    if (result != AVIF_RESULT_OK) {
+        PyErr_Format(
+            exc_type_for_avif_result(result),
+            "Setting IO memory failed: %s",
+            avifResultToString(result));
+        avifDecoderDestroy(decoder);
+        Py_XDECREF(avif_bytes);
+        PyObject_Del(self);
+        return NULL;
+    }
+
+    result = avifDecoderParse(decoder);
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
             exc_type_for_avif_result(result),
             "Failed to decode image: %s",
             avifResultToString(result));
-        avifDecoderDestroy(self->decoder);
-        self->decoder = NULL;
-        Py_DECREF(self);
+        avifDecoderDestroy(decoder);
+        Py_XDECREF(avif_bytes);
+        PyObject_Del(self);
         return NULL;
     }
 
-    if (self->decoder->alphaPresent) {
-        self->mode = "RGBA";
-    } else {
-        self->mode = "RGB";
-    }
+    self->decoder = decoder;
+    self->data = avif_bytes;
 
     return (PyObject *)self;
 }
@@ -861,13 +891,14 @@ _decoder_get_info(AvifDecoderObject *self) {
     }
 
     ret = Py_BuildValue(
-        "IIIsSSS",
+        "IIIsSSIS",
         image->width,
         image->height,
         decoder->imageCount,
-        self->mode,
+        decoder->alphaPresent ? "RGBA" : "RGB",
         NULL == icc ? Py_None : icc,
         NULL == exif ? Py_None : exif,
+        irot_imir_to_exif_orientation(image),
         NULL == xmp ? Py_None : xmp);
 
     Py_XDECREF(xmp);
@@ -887,7 +918,6 @@ _decoder_get_frame(AvifDecoderObject *self, PyObject *args) {
     avifDecoder *decoder;
     avifImage *image;
     uint32_t frame_index;
-    uint32_t row_bytes;
 
     decoder = self->decoder;
 
@@ -896,42 +926,35 @@ _decoder_get_frame(AvifDecoderObject *self, PyObject *args) {
     }
 
     result = avifDecoderNthImage(decoder, frame_index);
-
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
             exc_type_for_avif_result(result),
             "Failed to decode frame %u: %s",
-            decoder->imageIndex + 1,
+            frame_index,
             avifResultToString(result));
         return NULL;
     }
 
     image = decoder->image;
 
-    memset(&rgb, 0, sizeof(rgb));
     avifRGBImageSetDefaults(&rgb, image);
 
     rgb.depth = 8;
+    rgb.format = decoder->alphaPresent ? AVIF_RGB_FORMAT_RGBA : AVIF_RGB_FORMAT_RGB;
+    rgb.chromaUpsampling = self->upsampling;
 
-    if (decoder->alphaPresent) {
-        rgb.format = AVIF_RGB_FORMAT_RGBA;
-    } else {
-        rgb.format = AVIF_RGB_FORMAT_RGB;
-        rgb.ignoreAlpha = AVIF_TRUE;
-    }
-
-    row_bytes = rgb.width * avifRGBImagePixelSize(&rgb);
-
-    if (rgb.height > PY_SSIZE_T_MAX / row_bytes) {
-        PyErr_SetString(PyExc_MemoryError, "Integer overflow in pixel size");
+    result = avifRGBImageAllocatePixels(&rgb);
+    if (result != AVIF_RESULT_OK) {
+        PyErr_Format(
+            exc_type_for_avif_result(result),
+            "Pixel allocation failed: %s",
+            avifResultToString(result));
         return NULL;
     }
 
-    avifRGBImageAllocatePixels(&rgb);
-
-    Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS;
     result = avifImageYUVToRGB(image, &rgb);
-    Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS;
 
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
@@ -939,6 +962,11 @@ _decoder_get_frame(AvifDecoderObject *self, PyObject *args) {
             "Conversion from YUV failed: %s",
             avifResultToString(result));
         avifRGBImageFreePixels(&rgb);
+        return NULL;
+    }
+
+    if (rgb.height > PY_SSIZE_T_MAX / rgb.rowBytes) {
+        PyErr_SetString(PyExc_MemoryError, "Integer overflow in pixel size");
         return NULL;
     }
 
@@ -1075,6 +1103,10 @@ MOD_INIT(_avif) {
     if (m == NULL || setup_module(m) < 0) {
         return MOD_ERROR_VAL;
     }
+
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
 
     return MOD_SUCCESS_VAL(m);
 }


### PR DESCRIPTION
Updates the pillow-avif-plugin code to more closely match the current state of the open Pillow PR, python-pillow/Pillow#5201. The differences that remain have to do with python 2.7 compatibility.

Most of the code changes from the Pillow PR are stylistic, not functional, but there are two bug fixes included:

- `AvifImagePlugin.CHROMA_UPSAMPLING `is now actually used by the decoder. Previously, although it was passed into the decoder, it did not have any effect. Note that this is different from the Pillow PR, where this functionality was removed instead.
- AVIF images with `irot` and `imir` now have those values converted to the equivalent EXIF orientation when decoded. EXIF orientation has been preserved by the encoder since 1.4.2, which is when we started setting irot and imir. But if such an image was converted to another format the orientation would have been lost.