### PR TITLE
fix: TypeError: 'float' object cannot be interpreted as an integer.

### DIFF
--- a/src/pillow_avif/AvifImagePlugin.py
+++ b/src/pillow_avif/AvifImagePlugin.py
@@ -287,7 +287,7 @@ def _save(im, fp, filename, save_all=False):
                 # Append the frame to the animation encoder
                 enc.add(
                     frame.tobytes("raw", rawmode),
-                    frame_duration,
+                    int(frame_duration),
                     frame.size[0],
                     frame.size[1],
                     rawmode,


### PR DESCRIPTION
Cast frame duration as an int to avoid TypeError

 Contains the fix from #68, which was inadvertently closed.