### PR TITLE
chore: Update libavif to v1.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         include:
         - python-version: "3.9"
           os: "ubuntu-22.04"
-          libavif-version: "88d3dccda111f6ccbcccd925179f67e7d6fdf4ff"
+          libavif-version: "1d469864478de5686a13c06b5539416ac68d98d7"
         - python-version: "3.7"
           PYTHONOPTIMIZE: 1
         - python-version: "3.8"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -267,7 +267,10 @@ jobs:
           echo "C:\Program Files\NASM" >> $env:GITHUB_PATH
 
           python.exe -m pip install meson
-          
+
+          curl -LO "https://github.com/lu-zero/cargo-c/releases/latest/download/cargo-c-windows-msvc.zip"
+          7z e -y "cargo-c-windows-msvc.zip" -o"${env:USERPROFILE}\.cargo\bin"
+
           & python.exe winbuild\build_prepare.py -v --architecture=${{ matrix.cibw_arch }}
         shell: pwsh
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -261,6 +261,9 @@ jobs:
         run: |
           python.exe -m pip install -r .ci/requirements-cibw.txt
 
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Prepare for build
         run: |
           choco install nasm --no-progress

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,7 +10,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "10.10"
   WHEEL_SDIR: wheelhouse
   CONFIG_PATH: pillow-avif-plugin/wheelbuild/config.sh
-  LIBAVIF_VERSION: 88d3dccda111f6ccbcccd925179f67e7d6fdf4ff
+  LIBAVIF_VERSION: 1.2.1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+Changes since 1.5.0 (unreleased)
+--------------------------------
+
+*  **CI**: Update libavif to 1.2.1. The only library version change since
+  1.5.0 is SVT-AV1, which was upgraded from 3.0.0 to 3.0.1. See the table
+  below for all AVIF codec versions in this release.
+
+.. table::
+
+  ===========  ==========
+  **libavif**  **1.2.1**
+  libaom       3.12.0
+  dav1d        1.5.1
+  **SVT-AV1**  **3.0.1**
+  rav1e        0.7.1
+  ===========  ==========
+
 1.5.0 (Mar 7, 2025)
 -------------------
 

--- a/depends/install_libavif.sh
+++ b/depends/install_libavif.sh
@@ -40,6 +40,7 @@ echo "::endgroup::"
 
 if [ "$LIBAVIF_VERSION" != "0.11.0" ]; then
     LIBAVIF_CMAKE_FLAGS+=(-DAVIF_LIBYUV=LOCAL)
+    HAS_EXT_DIR=
 fi
 
 HAS_DECODER=0
@@ -77,8 +78,10 @@ if [ "$HAS_ENCODER" != 1 ] || [ "$HAS_DECODER" != 1 ]; then
         pushd ext > /dev/null
         bash aom.cmd
         popd > /dev/null
+        LIBAVIF_CMAKE_FLAGS+=(-DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON)
+    else
+        LIBAVIF_CMAKE_FLAGS+=(-DAVIF_CODEC_AOM=LOCAL)
     fi
-    LIBAVIF_CMAKE_FLAGS+=(-DAVIF_CODEC_AOM=ON -DAVIF_LOCAL_AOM=ON)
     echo "::endgroup::"
 fi
 

--- a/depends/install_libavif.sh
+++ b/depends/install_libavif.sh
@@ -38,8 +38,8 @@ curl -sLo - \
 pushd libavif-$LIBAVIF_VERSION
 echo "::endgroup::"
 
-if [ "$LIBAVIF_VERSION" == "1.0.1" ]; then
-    patch -p1 < "${SCRIPT_DIR}/../wheelbuild/libavif-1.0.1-local-static.patch"
+if [ "$LIBAVIF_VERSION" != "0.11.0" ]; then
+    LIBAVIF_CMAKE_FLAGS+=(-DAVIF_LIBYUV=LOCAL)
 fi
 
 HAS_DECODER=0

--- a/wheelbuild/config.sh
+++ b/wheelbuild/config.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 CONFIG_DIR=$(abspath $(dirname "${BASH_SOURCE[0]}"))
 
 ARCHIVE_SDIR=pillow-avif-plugin-depends
-LIBAVIF_VERSION=4eb0a40fb06612adf53650a14c692eaf62c068e6
+LIBAVIF_VERSION=1.2.1
 RAV1E_VERSION=0.7.1
 CCACHE_VERSION=4.10.2
 SCCACHE_VERSION=0.10.0
@@ -335,8 +335,13 @@ EOF
 
     group_start "Download libavif source"
 
+    local libavif_archive="${LIBAVIF_VERSION}.tar.gz"
+    if [[ "$LIBAVIF_VERSION" == *"."* ]]; then
+        libavif_archive="v${libavif_archive}"
+    fi
+
     local out_dir=$(fetch_unpack \
-        "https://github.com/AOMediaCodec/libavif/archive/$LIBAVIF_VERSION.tar.gz" \
+        "https://github.com/AOMediaCodec/libavif/archive/$libavif_archive" \
         "libavif-$LIBAVIF_VERSION.tar.gz")
 
     group_end

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -110,7 +110,7 @@ ARCHITECTURES = {
 
 V = {
     "MESON": "1.5.1",
-    "LIBAVIF": "1.2.0",
+    "LIBAVIF": "1.2.1",
 }
 
 


### PR DESCRIPTION
Update libavif to 1.2.1. The only library version change since 1.5.0 is SVT-AV1, which was upgraded from 3.0.0 to 3.0.1. Fixes the logged warning in #72.