### PR TITLE
Prevent Pillow's AVIF plugin from replacing this plugin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Changes since 1.5.1 (unreleased)
+--------------------------------
+
+* **Fixed**: Make compatible with Pillow 11.2.1, by `@radarhere`_ (`#74`_).
+
+.. _#74: https://github.com/fdintino/pillow-avif-plugin/pull/74
+.. _@radarhere: https://github.com/radarhere
+
 1.5.1
 -----
 

--- a/src/pillow_avif/AvifImagePlugin.py
+++ b/src/pillow_avif/AvifImagePlugin.py
@@ -312,6 +312,12 @@ def _save(im, fp, filename, save_all=False):
     fp.write(data)
 
 
+# Prevent Pillow's AVIF plugin from replacing this plugin
+try:
+    from PIL import AvifImagePlugin
+except:
+    pass
+
 Image.register_open(AvifImageFile.format, AvifImageFile, _accept)
 if SUPPORTED:
     Image.register_save(AvifImageFile.format, _save)

--- a/src/pillow_avif/AvifImagePlugin.py
+++ b/src/pillow_avif/AvifImagePlugin.py
@@ -314,8 +314,8 @@ def _save(im, fp, filename, save_all=False):
 
 # Prevent Pillow's AVIF plugin from replacing this plugin
 try:
-    from PIL import AvifImagePlugin
-except:
+    from PIL import AvifImagePlugin  # noqa: F401
+except ImportError:
     pass
 
 Image.register_open(AvifImageFile.format, AvifImageFile, _accept)


### PR DESCRIPTION
I don't know what your plans are for this plugin, but a Pillow user recently reported that they [hoped to use both this plugin and Pillow 11.2.1](https://github.com/python-pillow/Pillow/issues/8886#issuecomment-2813504451). They found that Pillow's AVIF plugin was taking priority over this one.

Now, this is not always the case.
```python
from PIL import Image
import pillow_avif
im = Image.open("/Users/andrewmurray/pillow/Pillow/Tests/images/avif/hopper.avif")
print(im)
```
gives
```
<pillow_avif.AvifImagePlugin.AvifImageFile image mode=RGB size=128x128 at 0x102F1AEE0>
```
meaning that your plugin is used.

However, if I open another type of image first, that is not in [`preinit()`](https://github.com/python-pillow/Pillow/blob/3d4119521c853e1014012f73fdf9b2a8dc137722/src/PIL/Image.py#L338), so that all of Pillow's internal plugins are [loaded with `init()`](https://github.com/python-pillow/Pillow/blob/3d4119521c853e1014012f73fdf9b2a8dc137722/src/PIL/Image.py#L2529-L2536), then Pillow's plugin is used.
```python
from PIL import Image
import pillow_avif
Image.open("/Users/andrewmurray/pillow/Pillow/Tests/images/hopper.tif")
im = Image.open("/Users/andrewmurray/pillow/Pillow/Tests/images/avif/hopper.avif")
print(im)
```

The user could work around this, and I've [suggested how this could be done](https://github.com/python-pillow/Pillow/issues/8886#issuecomment-2814038881).

However, I don't think it's unreasonable if you want your plugin to consistently take priority. If they don't want your plugin, then one questions why they imported it.

This PR allows that to happen by importing Pillow's plugin within your plugin, so that your `register_open()` call occurs last. Since the user might still have an older Pillow without our AVIF plugin though, I'm catching exceptions.