### PR TITLE
fix: add Py_UNUSED parameters to AvifCodecVersions function to fix incompatible pointer types

### DIFF
--- a/src/pillow_avif/_avif.c
+++ b/src/pillow_avif/_avif.c
@@ -1064,7 +1064,7 @@ static PyTypeObject AvifDecoder_Type = {
 };
 
 PyObject *
-AvifCodecVersions() {
+AvifCodecVersions(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
     char codecVersions[256];
     avifCodecVersions(codecVersions);
     return PyUnicode_FromString(codecVersions);


### PR DESCRIPTION
Modified the AvifCodecVersions function signature to properly declare Py_UNUSED parameters for self and args, making it consistent with Python C extension conventions when arguments are unused.

This PR will fix the build time error:

```log
gcc -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python-pillow-avif-plugin/src=/usr/src/debug/python-pillow-avif-plugin -flto=auto -fPIC -I/usr/include/python3.13 -c src/pillow_avif/_avif.c -o build/temp.linux-x86_64-cpython-313/src/pillow_avif/_avif.o
src/pillow_avif/_avif.c:1100:27: error: initialization of ‘PyObject * (*)(PyObject *, PyObject *)’ {aka ‘struct _object * (*)(struct _object *, struct _object *)’} from incompatible pointer type ‘PyObject * (*)(void)’ {aka ‘struct _object * (*)(void)’} [-Wincompatible-pointer-types]
 1100 |     {"AvifCodecVersions", AvifCodecVersions, METH_NOARGS},
      |                           ^~~~~~~~~~~~~~~~~
src/pillow_avif/_avif.c:1100:27: note: (near initialization for ‘avifMethods[2].ml_meth’)
src/pillow_avif/_avif.c:1067:1: note: ‘AvifCodecVersions’ declared here
 1067 | AvifCodecVersions() {
      | ^~~~~~~~~~~~~~~~~
error: command '/usr/bin/gcc' failed with exit code 1
```